### PR TITLE
Update installation documentation for external use 

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,8 +1,16 @@
 # Root System Architecture, General Image Analysis GUI
 
-The RSA-GIA pipeline is the Topp Lab’s image processing pipeline for plants grown in a gel-based medium. The input is a set of images from the gel system. The output is a csv file of traits calculated from image processing.
+The RSA-GIA pipeline is the Topp Lab’s image processing pipeline for plants
+grown in a gel-based medium. The input is a set of images from the gel system.
+The output is a csv file of traits calculated from image processing.
 
-This appilcation is written in Java, and it was designed to run on a Linux system, namely CentOS. As such, installation and development guides will assume you are working in a Linux-based operating system.
+The pipeline acts a wrapper for the underlying CLI tools that have been
+developed over the years. Some of these tools have GUI versions as well, such
+as GiaRoots, which is referred to as Gia2D in the RSA-GIA pipeline.
+
+This appilcation is written in Java, and it was designed to run on a Linux
+system, namely CentOS. As such, installation and development guides will assume
+you are working in a Linux-based operating system.
 
 ---
 
@@ -142,16 +150,17 @@ sudo mysql_secure_installation
 
 #### Build
 
-Below is a barebones guide on building the project from scratch. A more in-depth
-guide will be provided in the future if needed.
+Maven is used to manage the project's dependencies and can be used to compile and package it.
 
-#### Java Package: `rsa-gia.jar`
+#### Java Package: `rsa-gui.jar`
 
-The basic instructions are to clone this repo and then open it IntelliJ CE. It prompts you to import as a Maven project, do so. It should add a sidebar on the right side of the interface named Maven that include *lifecycle* actions to _clean_, _compile_, and _package_ the project.
+**Note**: If you follow the installation guide, then the `.jar` included is named `rsa-gia*.jar` instead.
 
-To produce a `.jar` for release, use the _package_ action to compile and create the file. For single-file releases, use the package that includes dependencies.
+If you want to package the project for use, navigate to your clone of this repo and then run the following Maven command:
 
-In the future, this documentation will be updated with specific guidelines on how to configure your development environment.
+```bash
+mvn clean package
+```
 
 #### MySQL Configuration
 

--- a/install.sh
+++ b/install.sh
@@ -1,26 +1,4 @@
-# Installation
-
-Below is a full installation on how to install RSA-GiA onto a barebones instance
-of an operating system. This include changes to file system
-hierarchy, dependency installation, configuration of properties file, and
-compiling sub-components. For testing purposes, we suggest using a virtual
-machine. A guide on setting up a VirtualBox-based VM is provided in [doc/virtual-machine-setup.md](doc/virtual-machine-setup.md).
-
-## Dependencies
-
-In order to install and use this application, you will need to install or
-configure the following components onto a system.
-
-* [Java SE Runtime Environment 1.8](https://www.oracle.com/technetwork/java/javase/downloads/java-archive-javase8-2177648.html)
-* [Python 2.7 and Python 3](https://www.python.org/downloads/) and [pip](https://pip.pypa.io/en/stable/installing/)
-
-This installation guide includes installation of the application's interface.
-
-## CentOS 8
-
-Use the following commands to update the system and install dependencies
-
-```bash
+#!/usr/bin/env bash
 # Install dependencies
 dnf install -y ImageMagick libpng12 libXrender-devel libXrandr-devel libXfixes-devel libXinerama-devel fontconfig-devel freetype-devel libXi-devel libXt-devel libXext-devel libX11-devel libSM-devel libICE-devel glibc-devel libXtst-devel tinyxml gcc gcc-c++ maven
 
@@ -131,35 +109,3 @@ popd
 rm -rvf /opt/rsa-gia/target
 
 echo -e "Installation complete!\nMake sure to update '/etc/opt/rsa-gia/default.properties.' to point to your database server.\nYou will need to add any users to the 'rootarch' group before use.\nReboot required."
-```
-
-**Done!** RSA-GiA is now installed onto the system. Make sure to review the guides below on adding new users and overall administration of the software.
-
-## Alternative Binaries
-
-The Java-based GUI, `rsa-gia.jar`, is effectively a wrapper for a suite of CLI tools. Originally, these tools were installed individually. Currently, it is sufficient to copy the binaries from the working instance of Viper. I've put a copy of these files in `/shares/ctopp_share/data/repos/viper`. Additionally, a copy should be included in the `bin/` folder for this repository.
-
-However, the original versions are hosted by the Benfey lab.
-
-Benfey's Wiki: http://mk42ws.biology.duke.edu:8000/wiki/010-BenfeyLab/120-BioBusch/030-RootArch/150-RsaPipeline/090-Installation
-
-To install the original versions can be installed by downloading the RPM packages. These are installed into the `/usr/local/bin` folder. The RPM installation must be forced because some of the binaries and libraries are directly placed into the /usr/lib and /usr/bin directories which are owned by another package: `filesystem-3.2-25.el7`. The only file that may be overwritten is matlab in `/usr/bin/matlab`. It is included in `rsa-pipeline-admin-2.0.0-1`. If you have a version of matlab installed in this location, make sure to create a backup copy.
-
-```bash
-wget http://mk42ws.biology.duke.edu:8000/raw-attachment/wiki/010-BenfeyLab/120-BioBusch/030-RootArch/150-RsaPipeline/090-Installation/rsa-pipeline-rpm-2.tar.gz
-tar -zxvf rsa-pipeline-rpm-2.tar.gz
-rpm -ivh rsa-pipeline-rpm-2/* --force
-mv -v /usr/local/bin/gia* /opt/rsa-gia
-mv -v /usr/local/bin/matlab-programs /opt/rsa-gia
-mv -v /usr/local/bin/reconstruction* /opt/rsa-gia
-mv -v /usr/local/bin/rsa* /opt/rsa-gia
-mv -v /usr/local/bin/skeleton3D /opt/rsa-gia
-```
-
-## Testing
-
-Ni Jiang provided some sample data for testing RSA-GiA. It is a timeseries dataset using corn.
-
-```bash
-rsync -vrogP --chown=rsa-data:rootarch --chmod=D2775,F644 --stat tparker@stargate.datasci.danforthcenter.org:/shares/ctopp_share/data/rsa/original_images/corn/TIM/ /data/rsa/to_sort/root
-```


### PR DESCRIPTION
Updated documentation on how to install the application on a system that is external w.r.t. the Danforth Center. Also, I added a bash script to do the installation, assuming minimal dependencies are already installed.